### PR TITLE
Disable bot automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jdblischak @flying-sheep @ivirshup @jakakokosar @pavlin-policar
+* @flying-sheep @ivirshup @jakakokosar @jdblischak @pavlin-policar

--- a/README.md
+++ b/README.md
@@ -154,5 +154,6 @@ Feedstock Maintainers
 * [@flying-sheep](https://github.com/flying-sheep/)
 * [@ivirshup](https://github.com/ivirshup/)
 * [@jakakokosar](https://github.com/jakakokosar/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@pavlin-policar](https://github.com/pavlin-policar/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,7 @@ github:
   branch_name: main
   tooling_branch_name: main
 bot:
-  automerge: true
+  automerge: false
 conda_build:
   pkg_format: '2'
 test: native_and_emulated


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

The bot automerge is more trouble than its worth. It takes much less time to update the dependencies during the original update PR than to have to submit a repodata patch post-merge.