### PR TITLE
New 0.12.2 build without dask's `[array]` feature

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -138,7 +138,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/anndata-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ecb3e0613585f5b464d0d3cfb0043a981b2eb92efaa90aae9042dd3e289c4a0a
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
@@ -35,7 +35,7 @@ requirements:
     - awkward >=2.3.2
     - pyarrow <21
     - xarray >=2025.06.1
-    - dask[array] >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0
+    - dask >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0
 
 test:
   imports:


### PR DESCRIPTION
Looking more into my comment [here](https://github.com/conda-forge/anndata-feedstock/pull/56#issuecomment-3354234331), it seems that:
* conda doesn't support extra/feature definitions in package names (e.g. `dask[array]`), and
* the conda package `dask` contains the necessary pendencies that `[array]` would provide. That is, the dask feedstock [includes numpy](https://github.com/conda-forge/dask-feedstock/blob/adc96e614a4db8268501a256078cc5cc5a53dc4d/recipe/recipe.yaml#L30) which is what `dask[array]` [indicates](https://github.com/dask/dask/blob/3fb02e610cf2baf3ee570888e5e49159ee60c0e5/pyproject.toml#L50C1-L50C6).

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
