### PR TITLE
[ci skip] Use grayskull to auto-update dependencies

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,6 +6,7 @@ github:
   tooling_branch_name: main
 bot:
   automerge: false
+  inspection: update-grayskull
 conda_build:
   pkg_format: '2'
 test: native_and_emulated


### PR DESCRIPTION
@flying-sheep Do you want to try the option [`inspection: update-grayskull`](https://conda-forge.org/docs/maintainer/conda_forge_yml/#bot) to auto-update the dependencies? It has worked decently over in [conda-forge/ome-zarr-feedstock](https://github.com/conda-forge/ome-zarr-feedstock).

xref: https://github.com/conda-forge/anndata-feedstock/issues/66#issuecomment-3858817136, https://github.com/conda-forge/anndata-feedstock/pull/45